### PR TITLE
add bitbots_docs to package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,7 @@
   <depend>rospy</depend>
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>
+  <depend>bitbots_docs</depend>
 
   <build_depend>message_generation</build_depend>
   <build_depend>actionlib_msgs</build_depend>


### PR DESCRIPTION
## Proposed changes
I forgot to add `bitbots_docs` to the package.xml file.

## Related issues
#6

## Necessary checks
- [ ] Update package version
- [ ] Run linters
- [x] Run `catkin build`
- [ ] Write documentation
- [x] Test on your machine
- [x] Test on the robot

