### PR TITLE
foot scale only for one foot

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_msgs</name>
-  <version>0.2.0</version>
+  <version>0.2.1</version>
   <description>Messages for the code of the Hamburg Bit-Bots</description>
 
   <maintainer email="bestmann@informatik.uni-hamburg.de">Marc Bestmann</maintainer>

--- a/srv/FootScale.srv
+++ b/srv/FootScale.srv
@@ -1,11 +1,7 @@
-int8 L_L_F = 0
-int8 L_L_B = 1
-int8 L_R_F = 2
-int8 L_R_B = 3
-int8 R_L_F = 4
-int8 R_L_B = 5
-int8 R_R_F = 6
-int8 R_R_B = 7
+int8 L_F = 0
+int8 L_B = 1
+int8 R_F = 2
+int8 R_B = 3
 
 int8 sensor
 float32 weight


### PR DESCRIPTION
## Proposed changes
Since we have two separated pressure filters now, the message only needs 4 different sensors. The code to use this is already on master and also worked with the old message, this is just for clearing it up.

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [x] Write documentation
- [x] Create issues for future work
- [ ] Test on your machine
- [x] Test on the robot
- [x] Put the PR on our Project board

