### PR TITLE
Refactor/rename color space msg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ add_action_files(
 
 add_message_files(
   FILES
-  ColorSpace.msg
+  ColorLookupTable.msg
   Config.msg
   Cpu.msg
   FootPressure.msg

--- a/msg/ColorLookupTable.msg
+++ b/msg/ColorLookupTable.msg
@@ -1,4 +1,4 @@
-# A list of colors which describes a color-space.
+# A list of colors which describes a color lookup table.
 
 std_msgs/Header header
 


### PR DESCRIPTION
## Proposed changes
renamed ColorSpaceMsg to ColorLookupTableMsg
Merge together with bit-bots/bitbots_tools#66 and bit-bots/bitbots_vision#258

## Related issues
bit-bots/bitbots_vision#217

## Necessary checks
- [X] Run `catkin build`
- [X] Write documentation (all occurences in docs have been changed)
- [X] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

