### PR TITLE
fix kick action message

### DIFF
--- a/action/Kick.action
+++ b/action/Kick.action
@@ -1,6 +1,7 @@
 # goal definition
+# header.stamp should be base_footprint and the positions and directions should be in that frame
 std_msgs/Header header
-geometry_msgs/Vector3 ball_position
+geometry_msgs/Point ball_position
 geometry_msgs/Quaternion kick_direction
 float64 kick_speed
 


### PR DESCRIPTION
## Proposed changes
This changes the ball_position in the kick action message from vector3 to point which is required for the kick since https://github.com/bit-bots/bitbots_motion/pull/201.

## Necessary checks
- [x] Run `catkin build`
- [x] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

