### PR TITLE
change pipeline config to use new pipeline defaults

### DIFF
--- a/.rdmanifest
+++ b/.rdmanifest
@@ -1,0 +1,19 @@
+---
+# See http://doku.bit-bots.de/meta/manual/software/ci.html#make-package-resolvable-in-ci
+check-presence-script: '#!/bin/bash
+
+  test -d $BITBOTS_CATKIN_WORKSPACE/src/bitbots_msgs'
+depends:
+- roscpp
+- rospy
+- std_msgs
+- sensor_msgs
+- bitbots_docs
+- message_generation
+- actionlib_msgs
+- message_runtime
+exec-path: bitbots_msgs-master
+install-script: '#!/bin/bash
+
+  cp -r . $BITBOTS_CATKIN_WORKSPACE/src/bitbots_msgs'
+uri: https://github.com/bit-bots/bitbots_msgs/archive/refs/heads/master.tar.gz

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,5 +3,5 @@
 defineProperties()
 
 def pipeline = new BitbotsPipeline(this, env, currentBuild, scm)
-pipeline.configurePipelineForPackage(new PackagePipelineSettings(new PackageDefinition("bitbots_msgs", "."), true, true, !isChangeRequest()))
+pipeline.configurePipelineForPackage(new PackagePipelineSettings(new PackageDefinition("bitbots_msgs", ".")))
 pipeline.execute()


### PR DESCRIPTION
## Proposed changes
This PR changes the Jenkinsfile to use new pipeline defaults introduced in the jenkins library. It has the effect of making the pipeline more readable and also fixes a bug where documentation was published when running for branches which were not also filed as PR. This is uninteded behavior because we only want documentation to be published when running for the primary branch of a repository.

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

