### PR TITLE
Downgrade black for Ubuntu support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         - "--fix"
         - "--exit-non-zero-on-fix"
 - repo: https://github.com/psf/black
-  rev: 23.11.0
+  rev: 23.10.0  # keep this version for Ubuntu support
   hooks:
     - id: black
 - repo: https://github.com/pocc/pre-commit-hooks


### PR DESCRIPTION
Downgrade black for Ubuntu's pre-commit version (https://github.com/psf/black/pull/3940 is not supported)